### PR TITLE
Fix U move notation image

### DIFF
--- a/howtosolve.html
+++ b/howtosolve.html
@@ -34,7 +34,7 @@ span.alg {
    <tbody>
    <tr><td>Right:<br><span class="alg">R</span></td><td><img style="height: 6em;" src="/assets/Rmove.svg"/>
    <td>Left:<br><span class="alg">L</span></td><td><img style="height: 6em;" src="/assets/Lmove.svg"/></tr>
-   <tr><td>Up:<br><span class="alg">U</span></td><td><img style="height: 6em;" src="/assets/Rmove.svg"/>
+   <tr><td>Up:<br><span class="alg">U</span></td><td><img style="height: 6em;" src="/assets/Umove.svg"/>
    <td>Down:<br><span class="alg">D</span></td><td><img style="height: 6em;" src="/assets/Dmove.svg"/></tr>
    <tr><td>Front:<br><span class="alg">F</span></td><td><img style="height: 6em;" src="/assets/Fmove.svg"/>
    <td>Back:<br><span class="alg">B</span></td><td><img style="height: 6em;" src="/assets/Bmove.svg"/></tr>


### PR DESCRIPTION
## What changed

Updated the `Up / U` notation row to use `/assets/Umove.svg`.

## Why

The row incorrectly referenced `/assets/Rmove.svg`, causing the right-turn image to appear for both `R` and `U`.

## Impact

The notation table now shows the correct upper-face turn graphic for `U`.

## Validation

Confirmed that `assets/Umove.svg` exists and that the branch contains only the one-line image-reference change.